### PR TITLE
Current time to AI agent in university timezone

### DIFF
--- a/bff/ScheduleAI.Api/ScheduleAI.Core/Abstractions/Universities/IUniversity.cs
+++ b/bff/ScheduleAI.Api/ScheduleAI.Core/Abstractions/Universities/IUniversity.cs
@@ -31,4 +31,6 @@ public interface IUniversity
         CancellationToken cancellationToken = default);
 
     public Task<string?> GetGroupNameTemplate() => Task.FromResult<string?>(null);
+
+    public Task<TimeZoneInfo> GetTimeZone() => Task.FromResult<TimeZoneInfo>(TimeZoneInfo.Utc);
 }

--- a/bff/ScheduleAI.Api/Universities/Bmstu/BmstuUniversity.cs
+++ b/bff/ScheduleAI.Api/Universities/Bmstu/BmstuUniversity.cs
@@ -84,4 +84,10 @@ public class BmstuUniversity : IUniversity
                                             - `В` - вечерняя группа
                                         """);
     }
+
+    public Task<TimeZoneInfo> GetTimeZone()
+    {
+        return Task.FromResult(
+            TimeZoneInfo.CreateCustomTimeZone("moscow", TimeSpan.FromHours(3), "МСК", "Московское время"));
+    }
 }


### PR DESCRIPTION
Текущее время в AI агент теперь передается в таймзоне университета. Этого оказалось достаточно, чтобы он перестал что-то куда-то переводить и начал отвечать нормально.

Если текущая таймзона отлична от университетской, то все в принципе норм. Проблема, возможно, будет если мы добавим несколько универов в разных часовых поясах, и пользователь будет спрашивать не о своем